### PR TITLE
Add missing attribution for prestto and evieclutton

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,17 @@ plus.read_frame(plus.User.objects.all())
     </td></tr>
 </table>
 <!-- readme: contributors -end -->
+
+## Pair programmers
+
+Being a co-author of a commit doesn't show up in the contributor list above, so the following is for anyone who has paired on a commit and deserves credit.
+
+<!-- readme: evieclutton -start -->
+<!-- readme: evieclutton -end -->
+
+## Special thanks to Tom Preston
+
+Tom Preston did seminal work on Python paths that later became the foundation of dj-notebook.
+
+<!-- readme: prestto -start -->
+<!-- readme: prestto -start -->


### PR DESCRIPTION
- @prestto did seminal work on what later became the foundation of this project
- @evieclutton co-authored a pull request and doesn't show up in the contributor chart