### PR TITLE
Raise warning if not run in debug

### DIFF
--- a/src/dj_notebook/__init__.py
+++ b/src/dj_notebook/__init__.py
@@ -1,10 +1,12 @@
 import os
+import warnings
 
 import django
 from django.conf import settings as django_settings
 from django.core.management.color import no_style
 from django_extensions.management import shells
 from IPython.utils.capture import capture_output
+from rich import print as rich_print
 from rich.status import Status
 
 from .shell_plus import Plus
@@ -39,6 +41,11 @@ def activate(settings: str, quiet_load: bool = True) -> Plus:
             plus = Plus(shells.import_objects({"quiet_load": False}, no_style()))
 
         plus._import_object_history = c.stdout
+
+        # Log a warning message when DEBUG is set to False
+        if not plus.settings.DEBUG:
+            warnings.warn("Debug mode is turned off.")
+            rich_print("[red]WARNING: Debug mode is turned off.[/red]")
 
         if quiet_load is False:
             plus.print()

--- a/src/dj_notebook/__init__.py
+++ b/src/dj_notebook/__init__.py
@@ -45,7 +45,6 @@ def activate(settings: str, quiet_load: bool = True) -> Plus:
         # Log a warning message when DEBUG is set to False
         if not plus.settings.DEBUG:
             warnings.warn("Debug mode is turned off.")
-            rich_print("[red]WARNING: Debug mode is turned off.[/red]")
 
         if quiet_load is False:
             plus.print()

--- a/src/dj_notebook/__init__.py
+++ b/src/dj_notebook/__init__.py
@@ -6,7 +6,6 @@ from django.conf import settings as django_settings
 from django.core.management.color import no_style
 from django_extensions.management import shells
 from IPython.utils.capture import capture_output
-from rich import print as rich_print
 from rich.status import Status
 
 from .shell_plus import Plus
@@ -44,7 +43,7 @@ def activate(settings: str, quiet_load: bool = True) -> Plus:
 
         # Log a warning message when DEBUG is set to False
         if not plus.settings.DEBUG:
-            warnings.warn("Debug mode is turned off.")
+            warnings.warn("Django is running in production mode with dj-notebook.")
 
         if quiet_load is False:
             plus.print()

--- a/tests/test_dj_notebook.py
+++ b/tests/test_dj_notebook.py
@@ -140,7 +140,9 @@ def test_warning_when_debug_false(capfd):
     """
     Test if the correct warning and message are displayed when DEBUG is False.
 
-    Checks for error string message in both stout and warnings.warn.
+    Checks for error string message in both stout and warnings.
+    Test assumes that calling activate("fake_settings") results in
+    a state where DEBUG is False.
 
     Args:
         capfd: Pytest fixture to capture stdout and stderr.

--- a/tests/test_dj_notebook.py
+++ b/tests/test_dj_notebook.py
@@ -1,10 +1,11 @@
 from unittest.mock import patch
 
 import pytest
+import warnings
 
 from dj_notebook import Plus, activate
 from dj_notebook.shell_plus import DiagramClass
-
+from django.conf import settings
 
 def test_thing():
     plus = activate("test_harness")
@@ -134,3 +135,25 @@ def test_read_frame(mock_read_frame):
     # assert mocked query called
     mock_read_frame.assert_called_once_with(mock_qs)
     assert result == "Mocked DataFrame"
+
+
+def test_warning_when_debug_false(capfd):
+    """
+    Test if the correct warning and message are displayed when DEBUG is False.
+
+    Checks for error string message in both stout and warnings.warn. 
+
+    Args:
+        capfd: Pytest fixture to capture stdout and stderr.
+    """
+    
+    with pytest.warns(UserWarning) as record:
+        activate("fake_settings")  
+
+    # Capture STDOUT and STDERR
+    captured = capfd.readouterr()
+    
+    # Check stdout
+    assert "Debug mode is turned off." in captured.out
+    # Check warning message
+    assert "Debug mode is turned off." in str(record.list[0].message)

--- a/tests/test_dj_notebook.py
+++ b/tests/test_dj_notebook.py
@@ -152,9 +152,9 @@ def test_warning_when_debug_false(capfd):
         activate("fake_settings")
 
     # Capture STDOUT and STDERR
-    captured = capfd.readouterr()
+    capfd.readouterr()
 
-    # Check stdout
-    assert "Debug mode is turned off." in captured.out
     # Check warning message
-    assert "Debug mode is turned off." in str(record.list[0].message)
+    assert "Django is running in production mode with dj-notebook." in str(
+        record.list[0].message
+    )

--- a/tests/test_dj_notebook.py
+++ b/tests/test_dj_notebook.py
@@ -1,11 +1,10 @@
 from unittest.mock import patch
 
 import pytest
-import warnings
 
 from dj_notebook import Plus, activate
 from dj_notebook.shell_plus import DiagramClass
-from django.conf import settings
+
 
 def test_thing():
     plus = activate("test_harness")
@@ -141,18 +140,18 @@ def test_warning_when_debug_false(capfd):
     """
     Test if the correct warning and message are displayed when DEBUG is False.
 
-    Checks for error string message in both stout and warnings.warn. 
+    Checks for error string message in both stout and warnings.warn.
 
     Args:
         capfd: Pytest fixture to capture stdout and stderr.
     """
-    
+
     with pytest.warns(UserWarning) as record:
-        activate("fake_settings")  
+        activate("fake_settings")
 
     # Capture STDOUT and STDERR
     captured = capfd.readouterr()
-    
+
     # Check stdout
     assert "Debug mode is turned off." in captured.out
     # Check warning message


### PR DESCRIPTION
This should do it. 

_Two questions for reviewers:_

1. Should both or one of the following be kept?
warnings.warn("Debug mode is turned off.")
rich_print("[red]WARNING: Debug mode is turned off.[/red]")

I typically go with warnings for dev purposes including path etc. but the original issue stated to have warn AND another with red text.

2. What would you like the message to read?
