### PR TITLE
Remove special case for test harness from application code.

### DIFF
--- a/src/dj_notebook/__init__.py
+++ b/src/dj_notebook/__init__.py
@@ -16,25 +16,9 @@ def activate(settings: str, quiet_load: bool = True) -> Plus:
         "Loading dj-notebook...\n  Use Plus.print() to see what's been loaded.",
         spinner="bouncingBar",
     ):
-        if settings == "test_harness":
-            # Used for testing
-            # NOTE: This is bad code smell, we'll improve on it
-            #      when we have a better idea of what we're doing
-            django_settings.configure(
-                INSTALLED_APPS=[
-                    "django.contrib.admin",
-                    "django.contrib.auth",
-                    "django.contrib.contenttypes",
-                    "django.contrib.sessions",
-                    "django.contrib.messages",
-                    "django.contrib.staticfiles",
-                ]
-            )
-        else:
-            # Used for standard operations
-            os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings)
-            os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
-            django.setup()
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings)
+        os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+        django.setup()
 
         with capture_output() as c:
             plus = Plus(shells.import_objects({"quiet_load": False}, no_style()))

--- a/tests/config_debug_false.py
+++ b/tests/config_debug_false.py
@@ -1,0 +1,14 @@
+# This very incomplete configuration allows unit tests to take the same path as a standard call
+# to activate(). This one enables the test for a warning when DEBUG == False to pass.
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+]
+
+USE_TZ = True
+DEBUG = False

--- a/tests/config_test_harness.py
+++ b/tests/config_test_harness.py
@@ -1,0 +1,14 @@
+# This very incomplete configuration allows unit tests to take the same path as a standard call
+# to activate()
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+]
+
+USE_TZ = True
+DEBUG = True

--- a/tests/test_dj_notebook.py
+++ b/tests/test_dj_notebook.py
@@ -25,7 +25,7 @@ class SettingsCleaner:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self.old_settings_env is not None:
             environ["DJANGO_SETTINGS_MODULE"] = self.old_settings_env
-        else:
+        elif "DJANGO_SETTINGS_MODULE" in environ:
             del environ["DJANGO_SETTINGS_MODULE"]
         django.conf.settings = django.conf.LazySettings()
 


### PR DESCRIPTION
Addresses #88, at least partially.

This adds a context manager that ensures django settings are reset on exit, and has the two unit tests that call `activate()` use it.

It also adds two minimal settings modules that match the config those tests were seeing, and passes the names of those modules to `activate()` so that those are loaded using the same path as user-supplied settings modules.

I thought about using pytest-django's settings fixture, but the way `activate()` and `Plus` interact made that smell more than the original hack.