### PR TITLE
fix broken link to pycharm page from info box on installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,4 +11,4 @@ pip install dj-notebook
 
 !!! info "Using dj-notebook with PyCharm"
 
-    PyCharm users need to take a few extra steps described [here](/pycharm).
+    PyCharm users need to take a few extra steps described [here](../pycharm).


### PR DESCRIPTION
This PR turns it into a relative link like the one in the nav menu. Fixes #130 