### PR TITLE
Convert workflows to use UV instead of pip 

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -15,8 +15,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-           pip install '.[dev]'
+          python -m pip install uv
+          uv pip install -p ${{ matrix.python-version }} '.[dev]'
       - name: Lint with ruff and black
         run: |
           # stop the build if there are linting errors

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,8 +23,8 @@ jobs:
           python-version: 3.x
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install build
+          pip install uv
+          uv pip install -p 3.12 build
       - name: Build package
         run: |
           rm -rf dist


### PR DESCRIPTION
This uses instructions provided by in this article: https://daniel.feldroy.com/posts/til-2024-05-running-uv-outside-a-virtualenv

Closes #166.